### PR TITLE
Feature/generate-and-create-profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ blocks/
 segments/
 flows/
 campaigns/
+profiles/

--- a/README.md
+++ b/README.md
@@ -55,17 +55,27 @@ If you aren't sure what options and arguments to specify for a subcommand, use t
 klaviyo get campaigns --help
 ```
 
-Example command:
+Commands require a private API key to authenticate requests to Klaviyo. See [how to create a private API key](https://help.klaviyo.com/hc/en-us/articles/7423954176283) for information.
+
+**The recommended way to configure your API key is to run the `set api-key` command:**
+
+```bash
+klaviyo set api-key
+```
+
+This will prompt you for your key and save it to a `.env` file in your current directory. The CLI will automatically use this key for all future commands.
+
+Alternatively, the API key can be specified for a single command with the `--api-key` option or by setting the `KLAVIYO_API_KEY` environment variable.
+
+Example command using the `--api-key` option:
 
 ```bash
 klaviyo get campaigns --overwrite-mode keep-local --api-key pk_0000
 ```
 
-Commands require a private API key to authenticate requests to Klaviyo. See [how to create a private API key](https://help.klaviyo.com/hc/en-us/articles/7423954176283) for information. The API key can be specified with the `--api-key` command or by setting the `KLAVIYO_API_KEY` environment variable.
-
 # Command listing
 
-The following examples omit the `--api-key` command and assume that you have set the `KLAVIYO_API_KEY` environment variable.
+The following examples assume that you have set the `KLAVIYO_API_KEY` using the `klaviyo set api-key` command or by setting the `KLAVIYO_API_KEY` environment variable.
 
 ## `get`
 
@@ -99,6 +109,20 @@ If you want to retrieve all four supported resource types, use the `all` subcomm
 klaviyo get all --verbose
 ```
 
+## `set`
+
+The `set` command configures settings for the CLI.
+
+### `set api-key`
+
+This command securely prompts for your Klaviyo private API key and saves it to a `.env` file in the current working directory. This is the recommended way to configure authentication, as you will not need to provide the key with every command.
+
+```bash
+klaviyo set api-key
+```
+
+You will be prompted to enter your API key, and the input will be hidden for security.
+
 ## `inspect`
 
 The `inspect` command outputs a table with information about a resource based on a local resource definition file. The supported subcommands are `block`, `campaign`, `flow`, and `segment`.
@@ -116,7 +140,7 @@ The folder that stores the definition files can be specified using the relevant 
 
 ## `generate`
 
-The `generate` command creates a local resource definition file for a new resource. The supported subcommands are `campaign` and `block`.
+The `generate` command creates a local resource definition file for a new resource. The supported subcommands are `campaign`, `profile` and `block`.
 
 These commands will prompt you for parameters that are not provided as command options. For example, the following command will create a campaign definition file with the name attribute "Test Campaign", and then will interactively prompt you to select the lists and segments to use for the campaign audience from those that exist in your Klaviyo account, the campaign send strategy, and other parameters:
 
@@ -130,7 +154,7 @@ Newly-created resources may require additional steps to utilize. For example, a 
 
 ## `create`
 
-The `create` command creates a new Klaviyo resource based on a local definition file. The supported subcommands are `block`, `campaign`, `flow`, and `segment`.
+The `create` command creates a new Klaviyo resource based on a local definition file. The supported subcommands are `block`, `profile`, `campaign`, `flow`, and `segment`.
 
 The file is specified with the `--segment-file` option for segments, and the equivalent for other resource types. After creating the resource, the result will be saved to a new file with its assigned ID in the specified resource path (e.g. for a segment, the path specified with `--segment-path`, default `segments`).
 

--- a/kcli/constants.py
+++ b/kcli/constants.py
@@ -13,6 +13,7 @@ class ResourceType(Enum):
     FLOW = 'flow'
     CAMPAIGN = 'campaign'
     ALL = 'all'
+    PROFILE = "profile"
 
 class ReportResource(Enum):
     SEGMENT = 'segment'

--- a/kcli/kcli.py
+++ b/kcli/kcli.py
@@ -738,8 +738,11 @@ def generate_profile(context, profile_path: str):
             .strip()
             .lower()
         )
-        if profile_custom_property in ["yes", "no", "y", "n"]:
+        if profile_custom_property in ["yes", "y"]:
             profile_custom_property = True
+            break
+        elif profile_custom_property in ["no", "n"]:
+            profile_custom_property = False
             break
         click.secho("Invalid input. Please enter 'yes' or 'no'.", fg="red")
 

--- a/kcli/kcli.py
+++ b/kcli/kcli.py
@@ -808,6 +808,7 @@ def create_profile(context, profile_file: str, profile_path: str):
     if not cleaned_attributes.get("first_name"):
         raise click.UsageError("Profile must have a first name.")
 
+    tmp_profile_file = None
     try:
         tmp_profile_file = context.obj.write_generated_data_to_file(
             ResourceType.PROFILE, profile_data, profile_path


### PR DESCRIPTION
Adds profile resource type and creation commands

Implements the profile resource type, enabling the creation of profile definitions and pushing them to Klaviyo.

Introduces `generate profile` command for creating local profile definition files via interactive prompts.

Introduces `create profile` command for pushing local profile definitions to Klaviyo.

Adds validation for email and phone number formats.

Adds a utility function to recursively remove keys with None or empty string values from dictionaries.